### PR TITLE
Support form data and streams in body

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ function doRequest(method, url, options, callback) {
       callback = undefined;
     }
 
+    
     method = method.toUpperCase();
     options.headers = options.headers || {};
     var headers = caseless(options.headers);
@@ -49,40 +50,91 @@ function doRequest(method, url, options, callback) {
       headers.set('Content-Type', 'application/json');
     }
 
-    var body = options.body ? options.body : new Buffer(0);
-    if (typeof body === 'string') body = new Buffer(body);
-    assert(Buffer.isBuffer(body), 'body should be a Buffer or a String');
-    if (!headers.has('Content-Length')) {
-      headers.set('Content-Length', body.length);
+    var duplex = !(method === 'GET' || method === 'DELETE' || method === 'HEAD');
+    
+
+    var body;
+    if (duplex) {
+      body = options.body
+        ? options.body
+        : new Buffer(0);
+      if (typeof body === 'string') {
+        body = new Buffer(body);
+      }
+      assert(
+        Buffer.isBuffer(body) || typeof body.pipe === 'function',
+        'body should be a Buffer, String or Stream'
+      );
+      if (
+        typeof body.pipe === 'function' &&
+        typeof body.getHeaders === 'function' &&
+        typeof body.getLength === 'function'
+      ) {
+        var bodyHeaders = body.getHeaders();
+        Object.keys(bodyHeaders).forEach(function (header) {
+          if (!headers.has(header)) {
+            header.set(header, bodyHeaders[header]);
+          }
+        });
+        var gotLength = false;
+        body.getLength(function (err, length) {
+          if (gotLength) return;
+          gotLength = true;
+          if (err) return reject(
+            typeof err == 'string'
+            ? new Error(err)
+            : err
+          );
+          headers.set('Content-Length', length);
+          ready();
+        });
+      } else {
+        if (!headers.has('Content-Length')) {
+          headers.set('Content-Length', body.length);
+        }
+        ready();
+      }
+    } else if (options.body) {
+      throw new Error(
+        'You cannot pass a body to a ' + method + ' request.'
+      );
+    } else {
+      ready();
     }
+    
+    function ready() {
+      var req = module.exports._request(method, url, {
+        headers: options.headers,
+        followRedirects: options.followRedirects !== false,
+        maxRedirects: options.maxRedirects,
+        gzip: options.gzip !== false,
+        cache: options.cache,
+        timeout: options.timeout,
+        socketTimeout: options.socketTimeout,
+        retry: options.retry,
+        retryDelay: options.retryDelay,
+        maxRetries: options.maxRetries
+      }, function (err, res) {
+        if (err) return reject(err);
+        res.body.on('error', reject);
+        res.body.pipe(concat(function (body) {
+          resolve(
+            new Response(
+              res.statusCode,
+              res.headers, Array.isArray(body) ? new Buffer(0) : body,
+              result.url
+            )
+          );
+        }));
+      });
 
-    var req = module.exports._request(method, url, {
-      headers: options.headers,
-      followRedirects: options.followRedirects !== false,
-      maxRedirects: options.maxRedirects,
-      gzip: options.gzip !== false,
-      cache: options.cache,
-      timeout: options.timeout,
-      socketTimeout: options.socketTimeout,
-      retry: options.retry,
-      retryDelay: options.retryDelay,
-      maxRetries: options.maxRetries
-    }, function (err, res) {
-      if (err) return reject(err);
-      res.body.on('error', reject);
-      res.body.pipe(concat(function (body) {
-        resolve(
-          new Response(
-            res.statusCode,
-            res.headers, Array.isArray(body) ? new Buffer(0) : body,
-            result.url
-          )
-        );
-      }));
-    });
-
-    if (req) {
-      req.end(body);
+      if (duplex) {
+        if (typeof body.pipe === 'function') {
+          body.pipe(req);
+        } else {
+          req.end(body);
+        }
+      }
     }
   });
   result.getBody = function (encoding) {


### PR DESCRIPTION
This lets you pass a [form-data](https://github.com/form-data/form-data) object as the `body` argument.

[closes #13]
[closes #5]

**UNTESTED**
