### PR TITLE
When trying to determine whether the request is cross-domain, check t…

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -70,7 +70,7 @@ function doRequest(method, url, options, callback) {
     // handle cross domain
 
     var match;
-    var crossDomain = !!((match = /^([\w-]+:)?\/\/([^\/]+)/.exec(options.uri)) && (match[2] != window.location.host));
+    var crossDomain = !!((match = /^([\w-]+:)?\/\/([^\/]+)/.exec(url)) && (match[2] != window.location.host));
     if (!crossDomain) options.headers['X-Requested-With'] = 'XMLHttpRequest';
 
     // handle query string


### PR DESCRIPTION
…he request url instead of options.uri which might be set to something else

I didn't see `options.uri` documented anywhere and I don't see why `options.uri` would ever be different then `url`.