### PR TITLE
Ability to use agent option

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ function doRequest(method, url, options, callback) {
       maxRedirects: options.maxRedirects,
       gzip: options.gzip !== false,
       cache: options.cache,
+      agent: options.agent,
       timeout: options.timeout,
       socketTimeout: options.socketTimeout,
       retry: options.retry,


### PR DESCRIPTION
We would like to use custom agent object when we use the then-request. As far as I know http-basic library uses agent option. It would be great if then-request has this feature too.
