### PR TITLE
Fixed res.url at request done

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function doRequest(method, url, options, callback) {
           new Response(
             res.statusCode,
             res.headers, Array.isArray(body) ? new Buffer(0) : body,
-            result.url
+            url
           )
         );
       }));

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,7 @@ function testEnv(env) {
       assert(res.statusCode === 200);
       assert(res.headers['foo'] === 'bar');
       assert(res.body.toString() === 'body');
+      assert(res.url === 'http://example.com');
     });
   });
   test(env + ' - GET query', function () {


### PR DESCRIPTION
res.url is undefined, so could 'url' be used instead of result.url?