### PR TITLE
Avoid using deprecated Buffer constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ function handleBody(options: Options): NormalizedBody {
     body = Buffer.from(body);
   }
   if (!body) {
-    body = new Buffer(0);
+    body = Buffer.alloc(0);
   }
   if (!Buffer.isBuffer(body)) {
     if (typeof body.pipe === 'function') {
@@ -172,7 +172,7 @@ function request(method: HttpVerb, url: string, options: Options = {}): Response
             new GenericResponse(
               res.statusCode,
               res.headers,
-              Array.isArray(body) ? new Buffer(0) : body,
+              Array.isArray(body) ? Buffer.alloc(0) : body,
               res.url
             )
           );


### PR DESCRIPTION
Use `Buffer.alloc` instead of `new Buffer(number)`.

As support for old Node.js versions is already dropped, supported Node.js version range does not change.

Ref: a4f72af2ccca4d2fc6bc9635c85663b321edf077 (btw, I also suggest specifying `engines` property in `package.json` to print warnings upon installation on outdated Node.js version).

Alternative way would be to use `Buffer.concat([])` for zero-size buffers allocation, which is supported all the way down to 0.8.x.

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

Tracking: https://github.com/nodejs/node/issues/19079