### PR TITLE
Adding support XMLHttpRequest.withCredentials parameter

### DIFF
--- a/src/Options.ts
+++ b/src/Options.ts
@@ -17,6 +17,7 @@ interface Options {
   retryDelay?: number | ((err: NodeJS.ErrnoException | null, res: Response<NodeJS.ReadableStream | Buffer | string> | void, attemptNumber: number) => number);
   socketTimeout?: number;
   timeout?: number;
+  withCredentials?: boolean;
 
   isMatch?: (requestHeaders: IncomingHttpHeaders, cachedResponse: CachedResponse, defaultValue: boolean) => boolean;
   isExpired?: (cachedResponse: CachedResponse, defaultValue: boolean) => boolean;

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -108,6 +108,11 @@ function request(method: HttpVerb, url: string, options: Options): ResponsePromi
         reject(err);
       };
     }
+
+    if (options.withCredentials) {
+      xhr.withCredentials = options.withCredentials;
+    }
+
     xhr.onreadystatechange = function () {
       if (xhr.readyState === 4) {
         var headers: {[key: string]: string} = {};


### PR DESCRIPTION
Adding support XMLHttpRequest.withCredentials parameter for this issue: https://github.com/then/then-request/issues/43